### PR TITLE
Misc gfilter tweaks

### DIFF
--- a/R/gfilter.R
+++ b/R/gfilter.R
@@ -424,7 +424,11 @@ ChoiceItem <- setRefClass("ChoiceItem",
                                                        use.table=use.table,
                                                        expand=TRUE, fill=TRUE
                                                        )
-                             size(widget) <<- list(height= 4 * 25)
+                             if(length(u_x) >= 4){
+                                size(widget) <<- list(height= 4 * 25)
+                             } else {
+                                size(widget) <<- list(height= length(u_x) * 25)
+                             }
                              if(is.numeric(u_x))
                                widget$coerce_with <<- as.numeric
                              


### PR DESCRIPTION
Some changes are up for discussion (also see comments in extended descriptions). 
- 'select one level' seems to me more intuitive than the current label
- "Select multiple levels": one could argue that it is not technically accurate as you can also select one level, but "Select one or more of..." isn't accurate, too, as you would need to say "Select zero, one or more of..."; the latter is confusing and unnecessary, while "Select multiple levels" clearly conveys what this selector type is designed for. 
- "selector' instead of 'editor' could also be 'picker' or 'chooser' 
- using length(u_x) \* 25 for widget height can be dangerous if the line height is not 25 pixels. A line based unit of height for this would be useful. To work around we may want to add 5-10 pixels, just to be sure. 

And sorry for the messed up GIT changelog. I'm still learning my way around GIT and I wasn't sure how to get rid of my experimenting commits. 
