### PR TITLE
add previous/next buttons to the RadioItem filter

### DIFF
--- a/R/gfilter.R
+++ b/R/gfilter.R
@@ -27,7 +27,7 @@ NULL
 ##' w <- gwindow("Example of gfilter", visible=FALSE)
 ##' pg <- ggroup(container=w)
 ##' df <- gtable(DF, container=pg)
-##' a <- gfilter(df, initial.vars=data.frame(names(DF),
+##' a <- gfilter(df, initial.vars=data.frame(names(DF), names(DF),
 ##'                    c("single", "multiple", "range", "single", "range"),
 ##'                    stringsAsFactors=FALSE),
 ##'              allow.edit=TRUE,
@@ -36,7 +36,7 @@ NULL
 ##'                visible(df) <- h$obj$get_value()
 ##'              }
 ##'              )
-##' size(w) <- c(600, 400)
+##' size(w) <- c(600, 600)
 ##' visible(w) <- TRUE
 ##' }
 gfilter <- function(DF,


### PR DESCRIPTION
I've added prev/next buttons to the RadioItem filter. The only issue that I notice, and I suspect a bug in gcombobox(..., editable=TRUE, use_completion=TRUE), is the following: 
source https://raw.githubusercontent.com/landroni/gWidgets2-filter/master/gWidgets2-filter.R 

then 
`dffilter(iris)`
Add variable > Sepal.Length > Select one level
Using the combo select level 4.4
Now focus the input box and type 4.3
Notice that the "prev" button does NOT get disabled, although it should

It is as if `validx <- svalue(widget, index=TRUE)` didn't get properly updated, while `val <- svalue(widget)` did. 

Any ideas on what's going wrong? 
