### PR TITLE
Remove superfluous 'sep' argument breaking on R-devel

### DIFF
--- a/R/guiToolkit.R
+++ b/R/guiToolkit.R
@@ -105,7 +105,7 @@ guiToolkit <- function(name=NULL) {
 
   
   ## require the package
-  require(sprintf("gWidgets2%s", name, sep=""), character.only=TRUE)
+  require(sprintf("gWidgets2%s", name), character.only=TRUE)
 
 
   ## check for headless Gtk


### PR DESCRIPTION
Under the latest R-devel, new warning coming up:
```
one argument not used by format 'gWidgets2%s'
```
As far as I can tell the `sep` argument is unnecessary (maybe left over from previously using `paste`, or something similar?).